### PR TITLE
Latest `remotemaker` requires Python 3.12.

### DIFF
--- a/.github/workflows/publish-to-server.yaml
+++ b/.github/workflows/publish-to-server.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install remotemaker
         run: |
           python -m pip install ${{ vars.REMOTE_MAKER_WHEEL }}


### PR DESCRIPTION
 Otherwise GHA workflows will fail...